### PR TITLE
Include 'extra data' when returning list of results from filter / all operations

### DIFF
--- a/nap/resources.py
+++ b/nap/resources.py
@@ -6,6 +6,12 @@ from .serializers import JSONSerializer
 from .utils import make_url, handle_slash
 from .cache.base import CacheRequestsResponse
 
+class ListWithAttributes(list):
+    def __init__(self, list_vals, extra_data):
+        super(ListWithAttributes, self).__init__()
+        self.extend(list_vals)
+        self.extra_data = extra_data
+
 
 class DataModelMetaClass(type):
 
@@ -332,12 +338,6 @@ class ResourceModel(object):
         if not hasattr(obj_list, '__iter__'):
             raise ValueError('excpeted array-type response')
 
-        class ListWithAttributes(list):
-            def __init__(self, list_vals, extra_data):
-                super(ListWithAttributes, self).__init__()
-                self.extend(list_vals)
-                self.extra_data = extra_data
-        
         resource_list = [cls(**obj_dict) for obj_dict in obj_list]
         return ListWithAttributes(resource_list, extra_data)
 

--- a/nap/resources.py
+++ b/nap/resources.py
@@ -321,15 +321,25 @@ class ResourceModel(object):
         collection_field = cls._meta.get('collection_field')
         if collection_field:
             obj_list = r_data[collection_field]
+
+            extra_data = r_data.copy()
+            del(extra_data[collection_field])
+
         else:
             obj_list = r_data
+            extra_data = {}
 
         if not hasattr(obj_list, '__iter__'):
             raise ValueError('excpeted array-type response')
 
+        class ListWithAttributes(list):
+            def __init__(self, list_vals, extra_data):
+                super(ListWithAttributes, self).__init__()
+                self.extend(list_vals)
+                self.extra_data = extra_data
+        
         resource_list = [cls(**obj_dict) for obj_dict in obj_list]
-
-        return resource_list
+        return ListWithAttributes(resource_list, extra_data)
 
     def validate_collection_response(self, response):
         """Validate get response is valid to use for updating our object

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 test_requirements = ['mock', ]
 setup(
     name='nap',
-    version="0.2.2",
+    version="0.2.2a",
     description=('api access modeling and tools'),
     author="Jacob Burch",
     author_email="jacobburch@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 test_requirements = ['mock', ]
 setup(
     name='nap',
-    version="0.2.2a",
+    version="0.2.2b",
     description=('api access modeling and tools'),
     author="Jacob Burch",
     author_email="jacobburch@gmail.com",


### PR DESCRIPTION
Hi Jacob, 

When using nap's filter() or all() operations and the collection_field setting the code is currently throwing away any other top level keys in the response besides the collection field. I want these others fields too. This changes makes the following work:

sample response:
{ 'total_results': 45, 
  'results': [ ..... list of results ......] }

results = Resource.all()
total_results = results.extra_data['total_results']

I hope it's useful. 
