### PR TITLE
Travis-CI and Coveralls support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+  - "2.7"
+install:
+  - pip install slumber>=0.4.2
+  - pip install pytest-cov
+  - pip install coveralls
+script: make
+script:
+  py.test --cov nap --cov-report html
+after_success:
+  - coveralls

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,11 @@
 ===
 nap
 ===
+.. image:: https://travis-ci.org/jacobb/nap.png?branch=master
+   :target: https://travis-ci.org/jacobb/nap?branch=master
+
+.. image:: https://coveralls.io/repos/jacobb/nap/badge.png?branch=master
+   :target: https://coveralls.io/r/jacobb/nap/
 
 api access models and tools
 ===========================

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 
-test_requirements = ['mock', ]
+test_requirements = ['mock', 'pytest', 'pytest-cov']
 setup(
     name='nap',
     version="0.2.5",


### PR DESCRIPTION
This pull request:
- Adds support for Travis-CI unit testing
- Adds support for Coveralls coverage
- Adds badges for Travis and Coveralls to the README file
- Fixes #13 - Missing test requirements

There are two manual steps required to complete once this pull request is merged:
- Activate the github hook: https://travis-ci.org/profile
- Add the repo to: https://coveralls.io/  (see add repo button)
