### PR TITLE
Passthrough additional headers

### DIFF
--- a/nap/resources.py
+++ b/nap/resources.py
@@ -64,6 +64,7 @@ class ResourceModel(object):
         self._root_url = kwargs.get('root_url', self._meta['root_url'])
         self._saved = False
         self.update_fields(kwargs)
+        self.default_headers = kwargs.pop('headers', {})
 
     def update_fields(self, field_data):
         """Update object's values to values of field_data
@@ -155,6 +156,10 @@ class ResourceModel(object):
             root_url = self._meta['root_url']
         except KeyError:
             raise ValueError("Nap requests require root_url to be defined")
+
+        headers = kwargs.pop('headers', {})
+        headers.update(self.default_headers)
+        kwargs.update({'headers':headers})
 
         full_url = "%s%s" % (root_url, url)
         self.logger.info("Trying to hit %s" % full_url)


### PR DESCRIPTION
It doesn't seem like there's an adequate hook to pass headers through to the api behind the clinet.  One example of this would be header based authentication.  

I've taken an initial pass at supporting additional header values.  Please provide any additional feedback.
- Note Travis-CI is not supported in this branch.
