### PR TITLE
pass response to obj_from_response instead of response.content

### DIFF
--- a/nap/engine.py
+++ b/nap/engine.py
@@ -298,7 +298,7 @@ class ResourceEngine(object):
             return
 
         try:
-            obj = self.obj_from_response(response.content)
+            obj = self.obj_from_response(response)
         except ValueError:
             obj = None
 
@@ -354,7 +354,7 @@ class ResourceEngine(object):
             return
 
         try:
-            obj = self.obj_from_response(response.content)
+            obj = self.obj_from_response(response)
         except ValueError:
             obj = None
 


### PR DESCRIPTION
I believe obj_from_response takes the entire response object, and not response.content.
