### PR TITLE
Fix Attribute error when doing an update

### DIFF
--- a/nap/engine.py
+++ b/nap/engine.py
@@ -73,7 +73,7 @@ class ResourceEngine(object):
         ]
         for url in valid_urls:
             field_values = dict([
-                (var, getattr(self, var))
+                (var, getattr(resource_obj, var))
                 for var in url.required_vars
                 if getattr(resource_obj, var, None)
             ])


### PR DESCRIPTION
This was previously failing with AttributeError: 'ResourceEngine' object has no attribute 'XXX'
