### PR TITLE
Don't assume pagination is always active

### DIFF
--- a/nap/engine.py
+++ b/nap/engine.py
@@ -234,7 +234,7 @@ class ResourceEngine(object):
         serializer = self.get_serializer()
         r_data = serializer.deserialize(response.content)
         collection_field = self.model._meta.get('collection_field')
-        if collection_field:
+        if collection_field and collection_field in r_data:
             obj_list = r_data[collection_field]
 
             extra_data = r_data.copy()


### PR DESCRIPTION
In some API Framework, pagination can be disabled via query-string parameter (eg: `page_size=0`).

In that case the returned JSON is a list and not an object, and the `Resource.Meta.collection_field` won't be there.
