### PR TITLE
Respect instance root url

### DIFF
--- a/nap/engine.py
+++ b/nap/engine.py
@@ -275,6 +275,7 @@ class ResourceEngine(object):
             raise ValueError('No update url found')
 
         response = self._request(self.model._meta['update_method'], url,
+            resource_obj=resource_obj,
             data=self.serialize(resource_obj, for_read=True))
 
         self.validate_update_response(response)
@@ -317,6 +318,7 @@ class ResourceEngine(object):
         new_obj_data = self.serialize(resource_obj, for_read=True)
         response = self._request(
             'POST', self.get_create_url(resource_obj, **kwargs),
+            resource_obj=resource_obj,
             data=new_obj_data
         )
 
@@ -331,7 +333,8 @@ class ResourceEngine(object):
         """
 
         delete_url  = self.get_delete_url(resource_obj, **kwargs)
-        response = self._request('DELETE', delete_url)
+        response = self._request('DELETE', delete_url,
+                                 resource_obj=resource_obj)
 
         self.validate_delete_response(response)
         self.handle_delete_response(response)

--- a/nap/engine.py
+++ b/nap/engine.py
@@ -61,7 +61,7 @@ class ResourceEngine(object):
 
     # url methods
     def _generate_url(self, url_type='lookup', resource_obj=None, **kwargs):
-        """Iterates through object's URL list to find an approrpiate match
+        """Iterates through object's URL list to find an appropriate match
         between ``url_type`` and ``kwargs
 
         :param url_type: string representing the type of URL to find. options \

--- a/nap/engine.py
+++ b/nap/engine.py
@@ -13,13 +13,17 @@ class ResourceEngine(object):
         self.model = model
         self._tmp_request_args = {}
 
-    def _request(self, request_method, url, *args, **kwargs):
+    def _request(self, request_method, url, resource_obj=None, *args,
+                 **kwargs):
         "Construct a NapRequest and send it via a requests.rest call"
 
         try:
             root_url = self.model._meta['root_url']
         except KeyError:
             raise ValueError("Nap requests require root_url to be defined")
+
+        if resource_obj:
+            root_url = resource_obj._root_url
 
         full_url = "%s%s" % (root_url, url)
         self.logger.info("Trying to hit %s" % full_url)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -62,6 +62,24 @@ class TestResourceModelURLMethods(BaseResourceModelTest):
 
         self.engine.model._meta['urls'] = old_urls
 
+    @mock.patch('nap.engine.NapRequest')
+    def test_root_url(self, mock_request):
+        engine = self.get_engine()
+        instance = engine.model(root_url='the://instance/url/')
+
+        # Given: The instance override's Meta's root_url to be a new value
+        assert engine.model._meta['root_url'] != instance._root_url
+
+        # When: Sending a ``_request``
+        engine._request('GET', 'path/', resource_obj=instance)
+
+        assert mock_request.called  # preliminary
+
+        # Then: It uses the instance's root_url
+        expected_url = '{root}path/'.format(root=instance._root_url)
+        actual_url = mock_request.call_args[0][1]
+        assert actual_url == expected_url
+
 
 class TestResourceEngineAccessMethods(BaseResourceModelTest):
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -262,6 +262,59 @@ class TestResourceEngineWriteMethods(unittest.TestCase):
                 data=data, headers=self.headers, auth=None)
         SampleResourceModel._lookup_urls = []
 
+    @mock.patch('nap.engine.ResourceEngine.validate_create_response')
+    @mock.patch('nap.engine.ResourceEngine.handle_create_response')
+    @mock.patch('nap.engine.ResourceEngine._request')
+    def test_create_when_overriding_root_url(self, mock_request, *mocks):
+        # Given: An instance with a specialized root_url
+        dm = SampleResourceModel(root_url='the://instance/url/')
+
+        # When: Creating via instance's ResourceEngine
+        dm.objects.create(dm)
+
+        assert mock_request.called  # preliminary
+
+        # Then: It passes the instance to ``ResourceEngine._request``
+        kwargs = mock_request.call_args[1]
+        assert 'resource_obj' in kwargs
+        assert kwargs['resource_obj'] is dm
+
+    @mock.patch('nap.engine.ResourceEngine.get_update_url')
+    @mock.patch('nap.engine.ResourceEngine.validate_update_response')
+    @mock.patch('nap.engine.ResourceEngine.handle_update_response')
+    @mock.patch('nap.engine.ResourceEngine._request')
+    def test_update_when_overriding_root_url(self, mock_request, *mocks):
+        # Given: An instance with a specialized root_url
+        dm = SampleResourceModel(root_url='the://instance/url/')
+
+        # When: Updating via instance's ResourceEngine
+        dm.objects.update(dm)
+
+        assert mock_request.called  # preliminary
+
+        # Then: It passes the instance to ``ResourceEngine._request``
+        kwargs = mock_request.call_args[1]
+        assert 'resource_obj' in kwargs
+        assert kwargs['resource_obj'] is dm
+
+    @mock.patch('nap.engine.ResourceEngine.get_delete_url')
+    @mock.patch('nap.engine.ResourceEngine.validate_delete_response')
+    @mock.patch('nap.engine.ResourceEngine.handle_delete_response')
+    @mock.patch('nap.engine.ResourceEngine._request')
+    def test_delete_when_overriding_root_url(self, mock_request, *mocks):
+        # Given: An instance with a specialized root_url
+        dm = SampleResourceModel(root_url='the://instance/url/')
+
+        # When: Updating via instance's ResourceEngine
+        dm.objects.delete(dm)
+
+        assert mock_request.called  # preliminary
+
+        # Then: It passes the instance to ``ResourceEngine._request``
+        kwargs = mock_request.call_args[1]
+        assert 'resource_obj' in kwargs
+        assert kwargs['resource_obj'] is dm
+
     def test_write_with_no_lookup_url(self):
 
         from pytest import raises


### PR DESCRIPTION
Updates `ResourceEngine._request` to respect override of root_url via `ResourceModel(root_url='the://instance/url/')`.

Also updates `ResourceEngine.{create,update,delete}` to pass `resource_obj` into `._request`, so that in those scenarios it can get & respect `resource_obj._root_url`.
