### PR TITLE
Don't reset cache on responses retrieved fr cache

### DIFF
--- a/nap/engine.py
+++ b/nap/engine.py
@@ -35,13 +35,17 @@ class ResourceEngine(object):
         skip_cache = kwargs.get('skip_cache', False)
 
         use_cache = request_method in self.model._meta['cached_methods']\
-                    and not skip_cache
-
+            and not skip_cache
         if use_cache:
             self.logger.debug("Trying to get cached response for %s" % url)
             cached_response = self.cache.get(request)
             if cached_response:
                 self.logger.debug("Got cached response for %s" % url)
+
+                # Cached responses should not get re-cached to allow for
+                # expected timeouts. Now that we've retrieved the cached
+                # response, behave as if cache is turned off.
+                cached_response.use_cache = False
                 return cached_response
 
         resource_response = request.send()


### PR DESCRIPTION
Currently, retrieving a response from cache re-sets it's cache, and thus extends it's timeout. This goes against expected behavior, where the timeout is a "length we want this response to be considered live"
