### PR TITLE
refactor use of cache

### DIFF
--- a/nap/cache/base.py
+++ b/nap/cache/base.py
@@ -11,10 +11,10 @@ class BaseCacheBackend(object):
         self.obey_cache_headers = obey_cache_headers
         self.default_timeout = default_timeout
 
-    def get(self, response):
+    def get(self, key):
         return None
 
-    def set(self, response):
+    def set(self, key, value):
         return None
 
     def get_timeout_from_header(self, response):
@@ -25,19 +25,24 @@ class BaseCacheBackend(object):
         cache_header_age = re.search(r'max\-?age=(\d+)', cache_headers)
         return int(cache_header_age.group(1))
 
-    def get_cache_key(self, response, **kwargs):
+    def get_cache_key(self, model, url):
+
+        resource_name = model._meta['resource_name']
+        root_url = model._meta['root_url']
 
         key_parts = {
-            'url': response.url
+            'resource_name': resource_name,
+            'root_url': root_url,
+            'url': url,
         }
 
-        cache_key = "%(url)s" % key_parts
+        cache_key = "%(resource_name)s::%(root_url)s::%(url)s" % key_parts
 
         return cache_key
 
-    def get_timeout(self, response):
+    def get_timeout(self, response=None):
 
-        if self.obey_cache_headers:
+        if response and self.obey_cache_headers:
             header_timeout = self.get_timeout_from_header(response)
             if header_timeout:
                 return header_timeout

--- a/nap/cache/django_cache.py
+++ b/nap/cache/django_cache.py
@@ -9,11 +9,9 @@ from .base import BaseCacheBackend
 
 class DjangoCacheBackend(BaseCacheBackend):
 
-    def get(self, response):
-        key = self.get_cache_key(response)
+    def get(self, key):
         return cache.get(key)
 
-    def set(self, response):
-        key = self.get_cache_key(response)
+    def set(self, key, value, response=None):
         timeout = self.get_timeout(response)
         return cache.set(key, response, timeout)

--- a/nap/cache/django_cache.py
+++ b/nap/cache/django_cache.py
@@ -14,4 +14,4 @@ class DjangoCacheBackend(BaseCacheBackend):
 
     def set(self, key, value, response=None):
         timeout = self.get_timeout(response)
-        return cache.set(key, response, timeout)
+        return cache.set(key, value, timeout)

--- a/nap/http.py
+++ b/nap/http.py
@@ -4,14 +4,29 @@ import requests
 class NapResponse(object):
 
     def __init__(self, content, url, status_code,
-            use_cache=False, headers=None):
+            use_cache=None, headers=None, request_method=None):
         self.status_code = status_code
         self.content = content
         self.url = url
-        self.use_cache = use_cache
+        self._use_cache = use_cache
         if not headers:
             headers = {}
         self.headers = headers
+        self.request_method = request_method
+
+    @property
+    def use_cache(self):
+        """
+        use_cache must be explicitely set to False to bypass the cache.
+        This is usually done in the engine classes' get_from_cache method
+        """
+        if self._use_cache is False:
+            return False
+        return True
+
+    @use_cache.setter
+    def use_cache(self, val):
+        self._use_cache = val
 
 
 class NapRequest(object):

--- a/nap/http.py
+++ b/nap/http.py
@@ -20,9 +20,7 @@ class NapResponse(object):
         use_cache must be explicitely set to False to bypass the cache.
         This is usually done in the engine classes' get_from_cache method
         """
-        if self._use_cache is False:
-            return False
-        return True
+        return self._use_cache is not False
 
     @use_cache.setter
     def use_cache(self, val):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,5 +1,6 @@
 import mock
 import pytest
+from . import SampleResourceModel
 
 from nap.cache.base import BaseCacheBackend, DEFAULT_TIMEOUT
 
@@ -43,10 +44,15 @@ class TestBaseCacheBackend(object):
 
     def test_get_cache_key(self):
 
-        mock_response = self.get_fake_response()
+        obj = SampleResourceModel(
+            title='expected_title',
+            content='Blank Content'
+        )
         cache_backend = self.get_backend()
-        key = cache_backend.get_cache_key(mock_response)
-        assert key == 'http://www.foo.com/bar/'
+
+        uri = SampleResourceModel.objects.get_lookup_url(resource_obj=obj)
+        key = cache_backend.get_cache_key(SampleResourceModel, uri)
+        assert key == 'note::http://foo.com/v1/::expected_title/'
 
     def test_get_timeout_from_header(self):
 


### PR DESCRIPTION
This simplifies how cache is handled. Removes the responsibility of calculating keys from the response from the backend and moves it to the engine. This will make soon future additions of allowing objects calculate their own key, "refresh" themselves (by bypassing the cache and resetting), and deleting themselves from the cache.

The above features are a quick addition once this overhaul is approved.
