### PR TITLE
Add basic cache_key property on Resource objects

### DIFF
--- a/nap/resources.py
+++ b/nap/resources.py
@@ -149,6 +149,16 @@ class ResourceModel(object):
 
         return obj_dict
 
+    @property
+    def cache_key(self):
+
+        # This really needs to be cleaned up
+        lookup_url = self.objects.get_lookup_url(self)
+        full_url = self.objects.get_full_url(lookup_url)
+        cache_key = self.objects.cache.get_cache_key(self.__class__, full_url)
+
+        return cache_key
+
     # properties
     @property
     def full_url(self):

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -138,6 +138,11 @@ class TestReourceEtcMethods(object):
         assert dm != dm3
         assert dm != object()
 
+    def test_cache_key_method(self):
+        dm = SampleResourceModel(slug='some-slug')
+
+        assert dm.cache_key == "note::http://foo.com/v1/note/some-slug/"
+
 
 class TestResourceAuth(object):
 


### PR DESCRIPTION
Allow resource objects to be aware of their own basic lookup cache key, based on their properties.

This method shows that the current cache backend still needs rework, as having to pass the model around leads to some really hairy code paths. However, this will suffice until that structure can be cleaned up.
